### PR TITLE
implement travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: generic
+
+matrix:
+    include:
+        - os: osx
+          sudo: required
+          osx_image: xcode10
+        - os: osx
+          sudo: required
+          osx_image: xcode9.4
+          env: PRE_SDK=true
+
+install: brew bundle && bundle
+
+cache:
+  directories:
+    - OBJROOT
+    - DSTROOT
+    - SYMROOT
+  timeout: 1000
+
+script: ./travis-run.sh

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,2 @@
+brew "cmake"
+brew "subversion"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'xml-simple'
+gem 'minitest-fail-fast'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,17 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    minitest (5.11.3)
+    minitest-fail-fast (0.1.0)
+      minitest (~> 5)
     xml-simple (1.1.5)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  minitest-fail-fast
   xml-simple
+
+BUNDLED WITH
+   1.16.5

--- a/travis-run.sh
+++ b/travis-run.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+make rebuild && \
+  sudo make install DESTDIR=/Library/RubyMotion/BridgeSupport3 && \
+  cd test && rake


### PR DESCRIPTION
This PR adds a travis yml which instructs travis how to build and test the project on multiple versions of MacOS, and configures the cache so that subsequent builds are faster. It also adds a `Brewfile` that  can be run with `brew bundle` which installs the projects dependencies, and a `travis-run.sh` script that has the build and test process script for Travis. It also adds a dependency on the fail fast minitest ruby gem, just to make fixing big bugs a little bit easier.