### PR TITLE
hacky fix for 10.14 ruby segfault

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ##
-# Makefile for BridgeSupport 
+# Makefile for BridgeSupport
 ##
 ifdef RC_ProjectName
 Project = $(RC_ProjectName)
@@ -23,7 +23,7 @@ ORDERED_ARCHS = $(filter %64,$(RC_ARCHS)) $(filter-out %64,$(RC_ARCHS))
 RC_CFLAGS = $(foreach arch,$(RC_ARCHS),-arch $(arch)) -pipe
 
 RSYNC = /usr/bin/rsync -rlpt
-RUBY = ruby
+RUBY = $(PWD)/ruby_wrapper
 
 ifneq ("$(wildcard /usr/local/bin/gcc-4.2)","")
 	CC = gcc-4.2
@@ -49,7 +49,7 @@ else # !BridgeSupport_ext
 BS_LIBS = $(DSTROOT)/System/Library/BridgeSupport
 endif # !BridgeSupport_ext
 BS_INCLUDE = $(BS_LIBS)/include
-BS_RUBY := $(BS_LIBS)/ruby-$(shell $(RUBY) -e 'puts RUBY_VERSION.sub(/^(\d+\.\d+)(\..*)?$$/, "\\1")')
+BS_RUBY := $(BS_LIBS)/ruby-$(shell $(RUBY) -e 'puts RUBY_VERSION.split(\".\")[0..1].join(\".\")')
 RUBYLIB = $(BS_RUBY)
 
 LIBSYSTEM_HEADERS = /usr/include/asl.h /usr/include/notify*.h /usr/include/copyfile.h /usr/include/sandbox.h /usr/include/launch.h /usr/include/CommonCrypto/*.h
@@ -209,7 +209,9 @@ BRIDGESUPPORT_5 = $(DSTROOT)$(MANDIR)/man5/BridgeSupport.5
 $(BRIDGESUPPORT_5): $(DSTROOT_MADE)
 	$(MKDIR) $(USR_BIN)
 	$(INSTALL_PROGRAM) gen_bridge_metadata.rb $(USR_BIN)/gen_bridge_metadata
+	$(INSTALL_PROGRAM) ruby_wrapper $(USR_BIN)/gen_bridge_metadata_ruby_wrapper
 	$(CHMOD) +x $(USR_BIN)/gen_bridge_metadata
+	$(CHMOD) +x $(USR_BIN)/gen_bridge_metadata_ruby_wrapper
 	$(MKDIR) $(DTDS)
 	$(CP) BridgeSupport.dtd $(DTDS)
 	$(MKDIR) $(DSTROOT)$(MANDIR)/man1
@@ -265,5 +267,5 @@ rebuild:
 	rm -rf $(DSTROOT_MADE)
 	rm -rf $(SYMROOT_MADE)
 	rm -rf $(SWIG_DIR)
+	rm -f $(SRCROOT)/swig/Makefile
 	make
-

--- a/gen_bridge_metadata.rb
+++ b/gen_bridge_metadata.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/perl -e$_=$ARGV[0];exec(s/\w+$/gen_bridge_metadata_ruby_wrapper/r,$_)
 # -*- coding: utf-8; mode: ruby; indent-tabs-mode: true; ruby-indent-level: 4; tab-width: 8 -*-
 # Copyright (c) 2006-2012, Apple Inc. All rights reserved.
 # Copyright (c) 2005-2006 FUJIMOTO Hisakuni

--- a/ruby_wrapper
+++ b/ruby_wrapper
@@ -1,0 +1,18 @@
+#!/usr/bin/ruby
+require 'tmpdir'
+require 'fileutils'
+
+args = ARGV.map {|a| a =~ /\ / ? '"' + a + '"' : a}.join ' '
+macos_version = `/usr/bin/sw_vers -productVersion`.strip
+ruby = RbConfig.ruby
+system_ruby = ruby.start_with? '/System'
+
+# Fix for broken 10.14 Ruby
+if macos_version == '10.14' && system_ruby
+  dir = Dir.mktmpdir("bridgesupport-ruby")
+  FileUtils.cp(ruby, dir)
+  ruby = "#{dir}/#{File.basename ruby}"
+end
+
+exec "#{ruby} #{args}"
+

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -2,10 +2,11 @@ require "xmlsimple"
 
 def gen_bridge_metadata(header_file_name, option = {})
   version = RUBY_VERSION.sub(/^(\d+\.\d+)(\..*)?$$/, "\\1")
-  command = "RUBYLIB='../DSTROOT/System/Library/BridgeSupport/ruby-#{version}' ruby ../gen_bridge_metadata.rb --format complete"
+  command = "RUBYLIB='../DSTROOT/System/Library/BridgeSupport/ruby-#{version}' ../ruby_wrapper ../gen_bridge_metadata.rb --format complete"
   output_path = "/tmp/bs_test.bridgesupport"
-  system "#{command} -c '-I. -I./header #{option[:cflags]}' ./header/#{header_file_name} -o #{output_path}"
-
+  full_command = "#{command} -c '-I. -I./header #{option[:cflags]}' ./header/#{header_file_name} -o #{output_path}"
+  system full_command
+  raise "Could not create BridgeSupport file\nCommand: #{full_command}" unless File.exists? output_path
   XmlSimple.xml_in(open(output_path))
 end
 


### PR DESCRIPTION
This PR introduces a `ruby_wrapper` script that is invoked instead of the system Ruby for running `gen_bridge_metadata`. The wrapper simply copies the system Ruby executable to a temporary directory, and then executes it from there. This circumvents some behavior in Mojave that disallows our linking to libruby and libclang from a native extension. The wrapper only does this on Mojave, if Apple does not fix this bug or 'security feature', it will have be changed to do this for upcoming versions as well (such as 10.14.1?).

Enabling the wrapper required invocation changes in the `Makefile`, in `gen_bridge_metadata.rb` and in the test helper.